### PR TITLE
Support the x-pagination OpenAPI extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,43 @@ The following rules are used to map the OpenAPI schema to SQL tables and columns
   columns, with numeric suffixes (`_2`, `_3`, etc.). Request body fields have a
   `_req` suffix.
 
+## OpenAPI Extensions
+
+OpenAPI allows using custom extensions - adding custom fields anywhere in the
+schema as long as they're prefixed with an `X`. Such custom extensions are used
+to fine-tune this connector.
+
+If the original service cannot be modified to include an extension in a
+generated OpenAPI schema, save it locally and modify as needed.
+
+### Pagination
+
+APIs can use 4 different types of pagination:
+* Offset - every response can include an offset parameter, telling how many
+  results to skip.
+* Page - every response can include a page parameter; the number of results per
+  page can be configurable with another parameter.
+* Cursor/token - the response includes the value of a cursor or token,
+  that needs to be included in the next request.
+* Next page URL - the response includes an URL of the next set of results.
+
+The connector currently supports only the `Page` pagination.
+
+To enable pagination, add a `x-pagination` section in the path's operation section:
+
+```
+paths:
+  /records:
+    get:
+      responses:
+        # ...
+      x-pagination:
+       pageParam: "page"
+       limitParam: "per-page"
+       resultsPath: "$response.body#/workflows"
+       totalResultsPath: "$response.body#/total_count"
+```
+
 ## Build
 
 Run all the unit tests:

--- a/src/main/java/pl/net/was/OpenApiRecordSetProvider.java
+++ b/src/main/java/pl/net/was/OpenApiRecordSetProvider.java
@@ -14,6 +14,7 @@
 
 package pl.net.was;
 
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
@@ -28,7 +29,6 @@ import io.trino.spi.connector.RecordSet;
 import io.trino.spi.type.Type;
 
 import java.util.List;
-import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 
@@ -72,11 +72,10 @@ public class OpenApiRecordSetProvider
                 .toList();
 
         Iterable<List<?>> rows = client.getRows((OpenApiTableHandle) table);
-        Iterable<List<?>> mappedRows = StreamSupport.stream(rows.spliterator(), false)
-                .map(row -> columnIndexes.stream()
-                        .map(row::get)
-                        .collect(toList()))
-                .collect(toList());
+        Iterable<List<?>> mappedRows = Iterables.transform(rows, row -> columnIndexes
+                .stream()
+                .map(row::get)
+                .collect(toList()));
 
         List<Type> mappedTypes = columnHandles.stream()
                 .map(OpenApiColumnHandle::getType)

--- a/src/main/java/pl/net/was/authentication/Authentication.java
+++ b/src/main/java/pl/net/was/authentication/Authentication.java
@@ -47,6 +47,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.stream.Collectors.joining;
+import static pl.net.was.authentication.AuthenticationScheme.BEARER;
 
 public class Authentication
         implements HttpRequestFilter
@@ -198,7 +199,7 @@ public class Authentication
     {
         scheme = requireNonNullElse(scheme, defaultAuthenticationScheme);
         String value;
-        if (scheme.equals("bearer")) {
+        if (scheme.toUpperCase(Locale.ENGLISH).equals(BEARER.toString())) {
             value = "Bearer " + bearerToken;
         }
         else {

--- a/src/test/java/pl/net/was/OpenApiQueryRunner.java
+++ b/src/test/java/pl/net/was/OpenApiQueryRunner.java
@@ -35,6 +35,11 @@ public class OpenApiQueryRunner
     public static QueryRunner createQueryRunner(Map<String, String> catalogProperties)
             throws Exception
     {
+        Logging logger = Logging.initialize();
+        logger.setLevel("pl.net.was", Level.DEBUG);
+        logger.setLevel("io.trino", Level.INFO);
+        logger.setLevel("io.airlift", Level.INFO);
+
         verify(catalogProperties.containsKey("spec-location") && catalogProperties.containsKey("base-uri"), "catalogProperties must include spec-location and base-uri");
         Session defaultSession = testSessionBuilder()
                 .setCatalog("openapi")
@@ -58,11 +63,6 @@ public class OpenApiQueryRunner
     public static void main(String[] args)
             throws Exception
     {
-        Logging logger = Logging.initialize();
-        logger.setLevel("pl.net.was", Level.DEBUG);
-        logger.setLevel("io.trino", Level.INFO);
-        logger.setLevel("io.airlift", Level.DEBUG);
-
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         if (System.getenv("OPENAPI_SPEC_LOCATION") == null || System.getenv("OPENAPI_BASE_URI") == null) {
             TestingOpenApiServer server = new TestingOpenApiServer();

--- a/src/test/java/pl/net/was/TestingOpenApiServer.java
+++ b/src/test/java/pl/net/was/TestingOpenApiServer.java
@@ -32,7 +32,6 @@ public class TestingOpenApiServer
     private final GenericContainer<?> dockerContainer;
 
     public TestingOpenApiServer()
-            throws InterruptedException
     {
         // Use the oldest supported OpenAPI version
         dockerContainer = new GenericContainer<>("openapitools/openapi-petstore:latest")


### PR DESCRIPTION
Pagination support allows the following:
* Unnest results from an array field.
* Make multiple requests to fetch all result pages in a single query.

Fixes #7, but will require some follow-up work, see new issues referencing this PR.