### PR TITLE
Fixed problem when OpenApiClient keept on adding new headers

### DIFF
--- a/src/main/java/pl/net/was/OpenApiClient.java
+++ b/src/main/java/pl/net/was/OpenApiClient.java
@@ -212,10 +212,10 @@ public class OpenApiClient
         }
         builder
                 .setUri(uri)
-                .addHeader(USER_AGENT, USER_AGENT_VALUE)
-                .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
-                .addHeader(ACCEPT, JSON_UTF_8.toString())
-                .addHeader("X-Trino-OpenAPI-Path", path);
+                .setHeader(USER_AGENT, USER_AGENT_VALUE)
+                .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .setHeader(ACCEPT, JSON_UTF_8.toString())
+                .setHeader("X-Trino-OpenAPI-Path", path);
         getFilterValues(table, method, "header").forEach((key, value) -> builder.addHeader(key, value.toString()));
 
         Request request = builder.build();


### PR DESCRIPTION
As the connector tries to utilize the pagination it call the service multiple times but every time it adds new headers until the header entity becomes to large.

Its all because `io.airlift.http.client.Request.Builder.addHeader` is used instead of `setHeader`.

Stacktrace:

`java.lang.RuntimeException: java.lang.IllegalArgumentException: Request header too large
	at pl.net.was.OpenApiClient$JsonResponseHandler.handleException(OpenApiClient.java:447)
	at pl.net.was.OpenApiClient$JsonResponseHandler.handleException(OpenApiClient.java:432)
	at io.airlift.http.client.jetty.JettyHttpClient.internalExecute(JettyHttpClient.java:832)
	at io.airlift.http.client.jetty.JettyHttpClient.doExecute(JettyHttpClient.java:755)
	at io.airlift.http.client.jetty.JettyHttpClient.execute(JettyHttpClient.java:672)
	at pl.net.was.OpenApiClient.makeRequest(OpenApiClient.java:223)
	at pl.net.was.OpenApiClient.lambda$getRows$0(OpenApiClient.java:159)
	at pl.net.was.OpenApiClient$1.hasNext(OpenApiClient.java:617)
	at com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:46)
	at io.trino.spi.connector.InMemoryRecordSet$InMemoryRecordCursor.advanceNextPosition(InMemoryRecordSet.java:110)
	at io.trino.spi.connector.RecordPageSource.getNextPage(RecordPageSource.java:88)
	at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:268)
	at io.trino.operator.Driver.processInternal(Driver.java:403)
	at io.trino.operator.Driver.lambda$process$8(Driver.java:306)
	at io.trino.operator.Driver.tryWithLock(Driver.java:709)
	at io.trino.operator.Driver.process(Driver.java:298)
	at io.trino.operator.Driver.processForDuration(Driver.java:269)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:890)
	at io.trino.execution.executor.dedicated.SplitProcessor.run(SplitProcessor.java:77)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.lambda$run$0(TaskEntry.java:201)
	at io.trino.$gen.Trino_testversion____20240925_114036_36.run(Unknown Source)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.run(TaskEntry.java:202)
	at io.trino.execution.executor.scheduler.FairScheduler.runTask(FairScheduler.java:172)
	at io.trino.execution.executor.scheduler.FairScheduler.lambda$submit$0(FairScheduler.java:159)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:76)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: java.lang.IllegalArgumentException: Request header too large
	at org.eclipse.jetty.client.transport.internal.HttpSenderOverHTTP$HeadersCallback.process(HttpSenderOverHTTP.java:183)
	at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:262)
	at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:243)
	at org.eclipse.jetty.client.transport.internal.HttpSenderOverHTTP.sendHeaders(HttpSenderOverHTTP.java:78)
	at org.eclipse.jetty.client.transport.HttpSender$ContentSender.process(HttpSender.java:541)
	at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:262)
	at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:243)
	at org.eclipse.jetty.client.transport.HttpSender.send(HttpSender.java:85)
	at org.eclipse.jetty.client.transport.internal.HttpChannelOverHTTP.send(HttpChannelOverHTTP.java:86)
	at org.eclipse.jetty.client.transport.HttpChannel.send(HttpChannel.java:142)
	at org.eclipse.jetty.client.transport.HttpConnection.send(HttpConnection.java:112)
	at org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP$Delegate.send(HttpConnectionOverHTTP.java:330)
	at org.eclipse.jetty.client.transport.internal.HttpConnectionOverHTTP.send(HttpConnectionOverHTTP.java:159)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:444)
	at org.eclipse.jetty.client.transport.HttpDestination.process(HttpDestination.java:420)
	at org.eclipse.jetty.client.transport.HttpDestination.process(HttpDestination.java:375)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:358)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:352)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:329)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:308)
	at org.eclipse.jetty.client.transport.HttpRequest.sendAsync(HttpRequest.java:751)
	at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:303)
	at org.eclipse.jetty.client.transport.HttpRequest.send(HttpRequest.java:744)
	at io.airlift.http.client.jetty.JettyHttpClient.internalExecute(JettyHttpClient.java:807)
	... 28 more`