### PR TITLE
Fix setting HTTP request headers when using pagination

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up the JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '22'
+          java-version: '23'
           distribution: 'temurin'
           server-id: github
           cache: 'maven'
@@ -25,12 +25,10 @@ jobs:
           JIRA_SITE: ${{ secrets.JIRA_SITE }}
           JIRA_USER: ${{ secrets.JIRA_USER }}
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-        run: mvn -B package
-      - name: Upload test report
-        uses: actions/upload-artifact@v4
+        run: ./mvnw -B package
+      - name: Annotate run
+        uses: trinodb/github-actions/action-surefire-report@b63800bedfbc7ab1ff2e5fe7eaecf5ab82ce6a70
         if: always()
         with:
-          name: test report ${{ github.job }}
-          path: |
-            **/surefire-reports/TEST-*.xml
-          retention-days: 5
+          fail_if_no_tests: false
+          skip_publishing: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up the JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '22'
+          java-version: '23'
           distribution: 'temurin'
           cache: 'maven'
 
@@ -70,14 +70,9 @@ jobs:
         with:
           setup-java: false
 
-      - name: Upload test report
-        uses: actions/upload-artifact@v4
+      - name: Annotate run
+        uses: trinodb/github-actions/action-surefire-report@b63800bedfbc7ab1ff2e5fe7eaecf5ab82ce6a70
         if: always()
         with:
-          name: test report ${{ github.job }}
-          path: |
-            release.properties
-            **/surefire-reports/TEST-*.xml
-            out/jreleaser/trace.log
-            out/jreleaser/output.properties
-          retention-days: 5
+          fail_if_no_tests: false
+          skip_publishing: true

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.8/apache-maven-3.9.8-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip


### PR DESCRIPTION
HTTP request values were being duplicated, increasing the size of every
subsequent request until it reached the max size.

Alternative to #122, but here we avoid passing a mutable object as a method parameter.
