### PR TITLE
Querying table with no predicates is emptying pagination params

### DIFF
--- a/src/main/java/pl/net/was/OpenApiClient.java
+++ b/src/main/java/pl/net/was/OpenApiClient.java
@@ -137,7 +137,8 @@ public class OpenApiClient
                     TupleDomain<ColumnHandle> pageConstraint = TupleDomain.fromFixedValues(Map.of(
                             pageColumn.get().getHandle(),
                             NullableValue.of(pageColumn.get().getType(), pageColumn.get().getType() instanceof BigintType ? (long) page : page)));
-                    OpenApiTableHandle pageTable = table.cloneWithConstraint(table.getConstraint().intersect(pageConstraint));
+                    TupleDomain<ColumnHandle> constraint = table.getConstraint().isNone() ? pageConstraint : table.getConstraint().intersect(pageConstraint);
+                    OpenApiTableHandle pageTable = table.cloneWithConstraint(constraint);
                     return makeRequest(pageTable, method, table.getSelectPath(), bodyGenerator, new JsonResponseHandler(table));
                 },
                 0,


### PR DESCRIPTION
Consider the following query:

```SQL
SELECT * FROM openapi."default".test_events s
```

When table (service) supports pagination and Table constraint is empty the `intersect()` would return empty causing the pagination params to be skipped.