### PR TITLE
fix date-time format error

### DIFF
--- a/src/main/java/pl/net/was/OpenApiClient.java
+++ b/src/main/java/pl/net/was/OpenApiClient.java
@@ -60,6 +60,7 @@ import java.net.URISyntaxException;
 import java.text.NumberFormat;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -350,7 +351,7 @@ public class OpenApiClient
             format = "yyyy-MM-dd'T'HH:mm:ss[.SSSSSSSSS][.SSSSSS][.SSS]XXX";
         }
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(format);
-        return dateFormatter.format(Instant.ofEpochMilli(millis));
+        return dateFormatter.format(Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC));
     }
 
     public ObjectNode serializePage(OpenApiTableHandle table, Page page, int position)


### PR DESCRIPTION
when a spec file has an input parameter like:
```
            "schema": {
              "format": "date-time",
              "type": "string"
```

and you need to 
```
select * from somecatalog.default.someendpoint where ts = TIMESTAMP '2025-04-18 12:30:45.123'
```

without this PR you'll get:
```
Query 20250421_163824_00171_9ag3c, FAILED, 1 node
Splits: 1 total, 0 done (0.00%)
0.12 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20250421_163824_00171_9ag3c failed: Unsupported field: YearOfEra
```

with a trace like this:
```
jshell> dateFormatter.format(Instant.ofEpochMilli(1745254365000L))
|  Exception java.time.temporal.UnsupportedTemporalTypeException: Unsupported field: YearOfEra
|        at Instant.getLong (Instant.java:604)
|        at DateTimePrintContext.getValue (DateTimePrintContext.java:308)
|        at DateTimeFormatterBuilder$NumberPrinterParser.format (DateTimeFormatterBuilder.java:2763)
|        at DateTimeFormatterBuilder$CompositePrinterParser.format (DateTimeFormatterBuilder.java:2402)
|        at DateTimeFormatter.formatTo (DateTimeFormatter.java:1849)
|        at DateTimeFormatter.format (DateTimeFormatter.java:1823)
|        at (#33:1)
```

but this PR allows this:
```
jshell> dateFormatter.format(Instant.ofEpochMilli(1745249894000L).atZone(ZoneOffset.UTC))
$35 ==> "2025-04-21T15:38:14.000Z"
```