### PR TITLE
Improve path selection

### DIFF
--- a/src/main/java/pl/net/was/HttpPath.java
+++ b/src/main/java/pl/net/was/HttpPath.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pl.net.was;
+
+import io.swagger.v3.oas.models.PathItem;
+
+import java.util.Comparator;
+
+public record HttpPath(PathItem.HttpMethod method, String path)
+        implements Comparable<HttpPath>
+{
+    private static final Comparator<HttpPath> COMPARATOR = Comparator.comparing(HttpPath::method).thenComparing(HttpPath::path);
+
+    @Override
+    public int compareTo(HttpPath other)
+    {
+        return COMPARATOR.compare(this, other);
+    }
+}

--- a/src/main/java/pl/net/was/OpenApiColumn.java
+++ b/src/main/java/pl/net/was/OpenApiColumn.java
@@ -36,8 +36,8 @@ public class OpenApiColumn
     private final JsonPointer resultsPointer;
     private final Type type;
     private final Schema<?> sourceType;
-    private final Map<HttpMethod, String> requiresPredicate;
-    private final Map<HttpMethod, String> optionalPredicate;
+    private final Map<HttpMethod, ParameterLocation> requiresPredicate;
+    private final Map<HttpMethod, ParameterLocation> optionalPredicate;
     private final ColumnMetadata metadata;
     private final boolean isPageNumber;
     private final OpenApiColumnHandle handle;
@@ -48,8 +48,8 @@ public class OpenApiColumn
             JsonPointer resultsPointer,
             Type type,
             Schema<?> sourceType,
-            Map<HttpMethod, String> requiresPredicate,
-            Map<HttpMethod, String> optionalPredicate,
+            Map<HttpMethod, ParameterLocation> requiresPredicate,
+            Map<HttpMethod, ParameterLocation> optionalPredicate,
             boolean isNullable,
             boolean isHidden,
             boolean isPageNumber,
@@ -98,12 +98,12 @@ public class OpenApiColumn
         return sourceType;
     }
 
-    public Map<HttpMethod, String> getRequiresPredicate()
+    public Map<HttpMethod, ParameterLocation> getRequiresPredicate()
     {
         return requiresPredicate;
     }
 
-    public Map<HttpMethod, String> getOptionalPredicate()
+    public Map<HttpMethod, ParameterLocation> getOptionalPredicate()
     {
         return optionalPredicate;
     }
@@ -188,8 +188,8 @@ public class OpenApiColumn
         private JsonPointer resultsPointer;
         private Type type;
         private Schema<?> sourceType;
-        private final SortedMap<HttpMethod, String> requiresPredicate = new TreeMap<>();
-        private final SortedMap<HttpMethod, String> optionalPredicate = new TreeMap<>();
+        private final SortedMap<HttpMethod, ParameterLocation> requiresPredicate = new TreeMap<>();
+        private final SortedMap<HttpMethod, ParameterLocation> optionalPredicate = new TreeMap<>();
         private boolean isNullable;
         private boolean isHidden;
         private boolean isPageNumber;
@@ -242,13 +242,13 @@ public class OpenApiColumn
             return this;
         }
 
-        public OpenApiColumn.Builder setRequiresPredicate(Map<HttpMethod, String> requiresPredicate)
+        public OpenApiColumn.Builder setRequiresPredicate(Map<HttpMethod, ParameterLocation> requiresPredicate)
         {
             this.requiresPredicate.putAll(requireNonNull(requiresPredicate, "requiresPredicate is null"));
             return this;
         }
 
-        public OpenApiColumn.Builder setOptionalPredicate(Map<HttpMethod, String> optionalPredicate)
+        public OpenApiColumn.Builder setOptionalPredicate(Map<HttpMethod, ParameterLocation> optionalPredicate)
         {
             this.optionalPredicate.putAll(requireNonNull(optionalPredicate, "optionalPredicate is null"));
             return this;

--- a/src/main/java/pl/net/was/OpenApiColumn.java
+++ b/src/main/java/pl/net/was/OpenApiColumn.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import static io.swagger.v3.oas.models.PathItem.HttpMethod;
 import static java.util.Objects.requireNonNull;
 
 public class OpenApiColumn
@@ -36,8 +35,8 @@ public class OpenApiColumn
     private final JsonPointer resultsPointer;
     private final Type type;
     private final Schema<?> sourceType;
-    private final Map<HttpMethod, ParameterLocation> requiresPredicate;
-    private final Map<HttpMethod, ParameterLocation> optionalPredicate;
+    private final Map<HttpPath, ParameterLocation> requiresPredicate;
+    private final Map<HttpPath, ParameterLocation> optionalPredicate;
     private final ColumnMetadata metadata;
     private final boolean isPageNumber;
     private final OpenApiColumnHandle handle;
@@ -48,8 +47,8 @@ public class OpenApiColumn
             JsonPointer resultsPointer,
             Type type,
             Schema<?> sourceType,
-            Map<HttpMethod, ParameterLocation> requiresPredicate,
-            Map<HttpMethod, ParameterLocation> optionalPredicate,
+            Map<HttpPath, ParameterLocation> requiresPredicate,
+            Map<HttpPath, ParameterLocation> optionalPredicate,
             boolean isNullable,
             boolean isHidden,
             boolean isPageNumber,
@@ -98,12 +97,12 @@ public class OpenApiColumn
         return sourceType;
     }
 
-    public Map<HttpMethod, ParameterLocation> getRequiresPredicate()
+    public Map<HttpPath, ParameterLocation> getRequiresPredicate()
     {
         return requiresPredicate;
     }
 
-    public Map<HttpMethod, ParameterLocation> getOptionalPredicate()
+    public Map<HttpPath, ParameterLocation> getOptionalPredicate()
     {
         return optionalPredicate;
     }
@@ -188,8 +187,8 @@ public class OpenApiColumn
         private JsonPointer resultsPointer;
         private Type type;
         private Schema<?> sourceType;
-        private final SortedMap<HttpMethod, ParameterLocation> requiresPredicate = new TreeMap<>();
-        private final SortedMap<HttpMethod, ParameterLocation> optionalPredicate = new TreeMap<>();
+        private final SortedMap<HttpPath, ParameterLocation> requiresPredicate = new TreeMap<>();
+        private final SortedMap<HttpPath, ParameterLocation> optionalPredicate = new TreeMap<>();
         private boolean isNullable;
         private boolean isHidden;
         private boolean isPageNumber;
@@ -242,13 +241,13 @@ public class OpenApiColumn
             return this;
         }
 
-        public OpenApiColumn.Builder setRequiresPredicate(Map<HttpMethod, ParameterLocation> requiresPredicate)
+        public OpenApiColumn.Builder setRequiresPredicate(Map<HttpPath, ParameterLocation> requiresPredicate)
         {
             this.requiresPredicate.putAll(requireNonNull(requiresPredicate, "requiresPredicate is null"));
             return this;
         }
 
-        public OpenApiColumn.Builder setOptionalPredicate(Map<HttpMethod, ParameterLocation> optionalPredicate)
+        public OpenApiColumn.Builder setOptionalPredicate(Map<HttpPath, ParameterLocation> optionalPredicate)
         {
             this.optionalPredicate.putAll(requireNonNull(optionalPredicate, "optionalPredicate is null"));
             return this;

--- a/src/main/java/pl/net/was/OpenApiSpec.java
+++ b/src/main/java/pl/net/was/OpenApiSpec.java
@@ -138,10 +138,10 @@ public class OpenApiSpec
                     .toList();
             if (pathItems.size() == 1) {
                 // create a new entry with the value unwrapped out of a list
+                Map.Entry<String, PathItem> firstEntry = groupEntry.getValue().getFirst();
                 tables.put(Map.entry(
                         groupEntry.getKey(),
-                        mergeColumns(getColumns(pathItems.getFirst(), groupEntry.getKey()))));
-                Map.Entry<String, PathItem> firstEntry = groupEntry.getValue().getFirst();
+                        mergeColumns(getColumns(pathItems.getFirst(), firstEntry.getKey()))));
                 Map<PathItem.HttpMethod, List<String>> tablePaths = methodsToPaths(firstEntry.getValue(), firstEntry.getKey());
                 handles.put(groupEntry.getKey(), tableHandle(groupEntry.getKey(), tablePaths));
                 continue;
@@ -306,8 +306,8 @@ public class OpenApiSpec
                     .map(propEntry -> getPredicateColumn(
                             propEntry.getKey(),
                             propEntry.getValue(),
-                            requiredProperties.contains(propEntry.getKey()) ? ImmutableMap.of(method, ParameterLocation.BODY) : ImmutableMap.of(),
-                            !requiredProperties.contains(propEntry.getKey()) ? ImmutableMap.of(method, ParameterLocation.BODY) : ImmutableMap.of(),
+                            requiredProperties.contains(propEntry.getKey()) ? ImmutableMap.of(new HttpPath(method, path), ParameterLocation.BODY) : ImmutableMap.of(),
+                            !requiredProperties.contains(propEntry.getKey()) ? ImmutableMap.of(new HttpPath(method, path), ParameterLocation.BODY) : ImmutableMap.of(),
                             !requiredProperties.contains(propEntry.getKey()),
                             false,
                             propEntry.getKey().equals(pagination.get(PAGINATION_PAGE_PARAM))))
@@ -339,8 +339,8 @@ public class OpenApiSpec
                         return getPredicateColumn(
                                 parameter.getName(),
                                 parameter.getSchema(),
-                                parameter.getRequired() ? ImmutableMap.of(method, parameterLocation) : ImmutableMap.of(),
-                                !parameter.getRequired() ? ImmutableMap.of(method, parameterLocation) : ImmutableMap.of(),
+                                parameter.getRequired() ? ImmutableMap.of(new HttpPath(method, path), parameterLocation) : ImmutableMap.of(),
+                                !parameter.getRequired() ? ImmutableMap.of(new HttpPath(method, path), parameterLocation) : ImmutableMap.of(),
                                 // always nullable, because they're only required as predicates, not in INSERT statements
                                 true,
                                 // keep pagination parameters as hidden columns, so it's possible to
@@ -507,8 +507,8 @@ public class OpenApiSpec
     private Optional<OpenApiColumn> getPredicateColumn(
             String sourceName,
             Schema<?> schema,
-            Map<PathItem.HttpMethod, ParameterLocation> requiredPredicate,
-            Map<PathItem.HttpMethod, ParameterLocation> optionalPredicate,
+            Map<HttpPath, ParameterLocation> requiredPredicate,
+            Map<HttpPath, ParameterLocation> optionalPredicate,
             boolean isNullable,
             boolean isHidden,
             boolean isPageNumber)

--- a/src/main/java/pl/net/was/OpenApiTableHandle.java
+++ b/src/main/java/pl/net/was/OpenApiTableHandle.java
@@ -28,11 +28,13 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.StandardErrorCode.INVALID_ROW_FILTER;
+import static java.util.Objects.requireNonNull;
 
 public class OpenApiTableHandle
         implements ConnectorTableHandle, Cloneable
@@ -40,37 +42,37 @@ public class OpenApiTableHandle
     private static final int INSTANCE_SIZE = SizeOf.instanceSize(OpenApiTableHandle.class);
 
     private final SchemaTableName schemaTableName;
-    private final String selectPath;
+    private final List<String> selectPaths;
     private final PathItem.HttpMethod selectMethod;
-    private final String insertPath;
+    private final List<String> insertPaths;
     private final PathItem.HttpMethod insertMethod;
-    private final String updatePath;
+    private final List<String> updatePaths;
     private final PathItem.HttpMethod updateMethod;
-    private final String deletePath;
+    private final List<String> deletePaths;
     private final PathItem.HttpMethod deleteMethod;
     private TupleDomain<ColumnHandle> constraint;
 
     @JsonCreator
     public OpenApiTableHandle(
             SchemaTableName schemaTableName,
-            String selectPath,
+            List<String> selectPaths,
             PathItem.HttpMethod selectMethod,
-            String insertPath,
+            List<String> insertPaths,
             PathItem.HttpMethod insertMethod,
-            String updatePath,
+            List<String> updatePaths,
             PathItem.HttpMethod updateMethod,
-            String deletePath,
+            List<String> deletePaths,
             PathItem.HttpMethod deleteMethod,
             TupleDomain<ColumnHandle> constraint)
     {
         this.schemaTableName = schemaTableName;
-        this.selectPath = selectPath;
+        this.selectPaths = requireNonNull(selectPaths, "selectPaths is null");
         this.selectMethod = selectMethod;
-        this.insertPath = insertPath;
+        this.insertPaths = requireNonNull(insertPaths, "insertPaths is null");
         this.insertMethod = insertMethod;
-        this.updatePath = updatePath;
+        this.updatePaths = requireNonNull(updatePaths, "updatePaths is null");
         this.updateMethod = updateMethod;
-        this.deletePath = deletePath;
+        this.deletePaths = requireNonNull(deletePaths, "deletePaths is null");
         this.deleteMethod = deleteMethod;
         this.constraint = constraint;
     }
@@ -82,9 +84,9 @@ public class OpenApiTableHandle
     }
 
     @JsonProperty
-    public String getSelectPath()
+    public List<String> getSelectPaths()
     {
-        return selectPath;
+        return selectPaths;
     }
 
     @JsonProperty
@@ -94,9 +96,9 @@ public class OpenApiTableHandle
     }
 
     @JsonProperty
-    public String getInsertPath()
+    public List<String> getInsertPaths()
     {
-        return insertPath;
+        return insertPaths;
     }
 
     @JsonProperty
@@ -106,9 +108,9 @@ public class OpenApiTableHandle
     }
 
     @JsonProperty
-    public String getUpdatePath()
+    public List<String> getUpdatePaths()
     {
-        return updatePath;
+        return updatePaths;
     }
 
     @JsonProperty
@@ -118,9 +120,9 @@ public class OpenApiTableHandle
     }
 
     @JsonProperty
-    public String getDeletePath()
+    public List<String> getDeletePaths()
     {
-        return deletePath;
+        return deletePaths;
     }
 
     @JsonProperty
@@ -145,10 +147,10 @@ public class OpenApiTableHandle
     {
         return (long) INSTANCE_SIZE
                 + schemaTableName.getRetainedSizeInBytes()
-                + SizeOf.estimatedSizeOf(selectPath)
-                + SizeOf.estimatedSizeOf(insertPath)
-                + SizeOf.estimatedSizeOf(updatePath)
-                + SizeOf.estimatedSizeOf(deletePath)
+                + SizeOf.estimatedSizeOf(selectPaths, String::length)
+                + SizeOf.estimatedSizeOf(insertPaths, String::length)
+                + SizeOf.estimatedSizeOf(updatePaths, String::length)
+                + SizeOf.estimatedSizeOf(deletePaths, String::length)
                 + SizeOf.estimatedSizeOf(selectMethod.toString())
                 + SizeOf.estimatedSizeOf(insertMethod.toString())
                 + SizeOf.estimatedSizeOf(updateMethod.toString())

--- a/src/main/java/pl/net/was/ParameterLocation.java
+++ b/src/main/java/pl/net/was/ParameterLocation.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pl.net.was;
+
+public enum ParameterLocation
+{
+    NONE,
+    PATH,
+    QUERY,
+    HEADER,
+    BODY,
+    ANY
+}

--- a/src/test/java/pl/net/was/TestGithub.java
+++ b/src/test/java/pl/net/was/TestGithub.java
@@ -464,15 +464,13 @@ public class TestGithub
     @Test
     public void selectFromGithubActionsTable()
     {
-        // TODO remove the unused `workflow_id = 'a'` predicate
-        assertQuery("SELECT name FROM repos_actions_workflows WHERE owner = 'nineinchnick' AND repo = 'trino-openapi' AND name = 'Release with Maven' AND workflow_id = 'a'",
+        assertQuery("SELECT name FROM repos_actions_workflows WHERE owner = 'nineinchnick' AND repo = 'trino-openapi' AND name = 'Release with Maven'",
                 "VALUES ('Release with Maven')");
-        // TODO remove the unused `run_id = 1` predicate
-        assertQuery("SELECT name FROM repos_actions_runs WHERE owner = 'nineinchnick' AND repo = 'trino-openapi' AND name = 'Release with Maven' AND run_id = 1 LIMIT 1",
+        assertQuery("SELECT name FROM repos_actions_runs WHERE owner = 'nineinchnick' AND repo = 'trino-openapi' AND name = 'Release with Maven' LIMIT 1",
                 "VALUES ('Release with Maven')");
 
         QueryRunner runner = getQueryRunner();
-        long runId = (long) runner.execute("SELECT id FROM repos_actions_runs WHERE owner = 'nineinchnick' AND repo = 'trino-openapi' AND name = 'Release with Maven' AND run_id = 1 ORDER BY created_at DESC LIMIT 1").getOnlyValue();
+        long runId = (long) runner.execute("SELECT id FROM repos_actions_runs WHERE owner = 'nineinchnick' AND repo = 'trino-openapi' AND name = 'Release with Maven' ORDER BY created_at DESC LIMIT 1").getOnlyValue();
         assertThat(runId).isGreaterThan(0);
         long jobId = (long) runner.execute(format("SELECT id FROM repos_actions_runs_jobs WHERE owner = 'nineinchnick' AND repo = 'trino-openapi' AND run_id = %d LIMIT 1", runId)).getOnlyValue();
         assertThat(jobId).isGreaterThan(0);
@@ -494,8 +492,8 @@ public class TestGithub
         assertQuery("SELECT count(*) > 0 " +
                         "FROM repos_actions_workflows w " +
                         "JOIN repos_actions_runs r ON r.workflow_id = w.id " +
-                        "WHERE w.owner = 'nineinchnick' AND w.repo = 'trino-openapi' AND w.workflow_id = 'a' " +
-                        "AND r.owner = 'nineinchnick' AND r.repo = 'trino-openapi' AND r.run_id = 1",
+                        "WHERE w.owner = 'nineinchnick' AND w.repo = 'trino-openapi' " +
+                        "AND r.owner = 'nineinchnick' AND r.repo = 'trino-openapi'",
                 "VALUES (true)");
     }
 }

--- a/src/test/java/pl/net/was/TestOpenApiSpec.java
+++ b/src/test/java/pl/net/was/TestOpenApiSpec.java
@@ -87,10 +87,10 @@ class TestOpenApiSpec
         Assertions.assertThat(tables.keySet()).containsAll(expected);
 
         OpenApiTableHandle orgsTableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "orgs"));
-        Assertions.assertThat(orgsTableHandle.getSelectPath()).isEqualTo("/orgs/{org}");
-        Assertions.assertThat(orgsTableHandle.getInsertPath()).isNull();
-        Assertions.assertThat(orgsTableHandle.getUpdatePath()).isNull();
-        Assertions.assertThat(orgsTableHandle.getDeletePath()).isEqualTo("/orgs/{org}");
+        Assertions.assertThat(orgsTableHandle.getSelectPaths()).containsExactly("/orgs/{org}");
+        Assertions.assertThat(orgsTableHandle.getInsertPaths()).isEmpty();
+        Assertions.assertThat(orgsTableHandle.getUpdatePaths()).isEmpty();
+        Assertions.assertThat(orgsTableHandle.getDeletePaths()).containsExactly("/orgs/{org}");
         List<OpenApiColumn> orgColumns = tables.get("orgs").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute
@@ -450,10 +450,10 @@ This field is only visible to organization owners or members of a team with the 
                                 .build());
 
         OpenApiTableHandle workflowTableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "repos_actions_workflows"));
-        Assertions.assertThat(workflowTableHandle.getSelectPath()).isEqualTo("/repos/{owner}/{repo}/actions/workflows");
-        Assertions.assertThat(workflowTableHandle.getInsertPath()).isNull();
-        Assertions.assertThat(workflowTableHandle.getUpdatePath()).isNull();
-        Assertions.assertThat(workflowTableHandle.getDeletePath()).isNull();
+        Assertions.assertThat(workflowTableHandle.getSelectPaths()).containsExactly("/repos/{owner}/{repo}/actions/workflows", "/repos/{owner}/{repo}/actions/workflows/{workflow_id}");
+        Assertions.assertThat(workflowTableHandle.getInsertPaths()).isEmpty();
+        Assertions.assertThat(workflowTableHandle.getUpdatePaths()).isEmpty();
+        Assertions.assertThat(workflowTableHandle.getDeletePaths()).isEmpty();
         List<OpenApiColumn> workflowColumns = tables.get("repos_actions_workflows").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute
@@ -584,10 +584,10 @@ This field is only visible to organization owners or members of a team with the 
         Assertions.assertThat(tables.keySet()).containsAll(expected);
 
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "rest_api_3_search"));
-        Assertions.assertThat(tableHandle.getSelectPath()).isEqualTo("/rest/api/3/search");
-        Assertions.assertThat(tableHandle.getInsertPath()).isEqualTo("/rest/api/3/search");
-        Assertions.assertThat(tableHandle.getUpdatePath()).isEqualTo("/rest/api/3/search");
-        Assertions.assertThat(tableHandle.getDeletePath()).isNull();
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/rest/api/3/search");
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly("/rest/api/3/search");
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly("/rest/api/3/search");
+        Assertions.assertThat(tableHandle.getDeletePaths()).isEmpty();
         List<OpenApiColumn> columns = tables.get("rest_api_3_search").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute
@@ -778,10 +778,10 @@ This field is only visible to organization owners or members of a team with the 
                 "pet");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "pet"));
-        Assertions.assertThat(tableHandle.getSelectPath()).isEqualTo("/pet/{petId}");
-        Assertions.assertThat(tableHandle.getInsertPath()).isEqualTo("/pet");
-        Assertions.assertThat(tableHandle.getUpdatePath()).isEqualTo("/pet");
-        Assertions.assertThat(tableHandle.getDeletePath()).isEqualTo("/pet/{petId}");
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/pet/{petId}");
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly("/pet", "/pet/{petId}");
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly("/pet", "/pet/{petId}");
+        Assertions.assertThat(tableHandle.getDeletePaths()).containsExactly("/pet/{petId}");
         List<OpenApiColumn> petColumns = tables.get("pet").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute
@@ -883,10 +883,10 @@ This field is only visible to organization owners or members of a team with the 
                 "api_v2_query_timeseries");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "api_v2_query_timeseries"));
-        Assertions.assertThat(tableHandle.getSelectPath()).isEqualTo("/api/v2/query/timeseries");
-        Assertions.assertThat(tableHandle.getInsertPath()).isEqualTo("/api/v2/query/timeseries");
-        Assertions.assertThat(tableHandle.getUpdatePath()).isEqualTo("/api/v2/query/timeseries");
-        Assertions.assertThat(tableHandle.getDeletePath()).isNull();
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/api/v2/query/timeseries");
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly("/api/v2/query/timeseries");
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly("/api/v2/query/timeseries");
+        Assertions.assertThat(tableHandle.getDeletePaths()).isEmpty();
         List<OpenApiColumn> columns = tables.get("api_v2_query_timeseries").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute
@@ -963,10 +963,10 @@ This field is only visible to organization owners or members of a team with the 
                 "zones");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "zones"));
-        Assertions.assertThat(tableHandle.getSelectPath()).isEqualTo("/zones");
-        Assertions.assertThat(tableHandle.getInsertPath()).isEqualTo("/zones");
-        Assertions.assertThat(tableHandle.getUpdatePath()).isEqualTo("/zones");
-        Assertions.assertThat(tableHandle.getDeletePath()).isEqualTo("/zones/{identifier}");
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/zones", "/zones/{identifier}");
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly("/zones");
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly("/zones");
+        Assertions.assertThat(tableHandle.getDeletePaths()).containsExactly("/zones/{identifier}");
         List<OpenApiColumn> columns = tables.get("zones").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute
@@ -1193,10 +1193,10 @@ This field is only visible to organization owners or members of a team with the 
                 "v1_forecast");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "v1_forecast"));
-        Assertions.assertThat(tableHandle.getSelectPath()).isEqualTo("/v1/forecast");
-        Assertions.assertThat(tableHandle.getInsertPath()).isNull();
-        Assertions.assertThat(tableHandle.getUpdatePath()).isNull();
-        Assertions.assertThat(tableHandle.getDeletePath()).isNull();
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/v1/forecast");
+        Assertions.assertThat(tableHandle.getInsertPaths()).isEmpty();
+        Assertions.assertThat(tableHandle.getUpdatePaths()).isEmpty();
+        Assertions.assertThat(tableHandle.getDeletePaths()).isEmpty();
         List<OpenApiColumn> columns = tables.get("v1_forecast").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute

--- a/src/test/java/pl/net/was/TestOpenApiSpec.java
+++ b/src/test/java/pl/net/was/TestOpenApiSpec.java
@@ -87,6 +87,7 @@ class TestOpenApiSpec
         Assertions.assertThat(tables.keySet()).containsAll(expected);
 
         OpenApiTableHandle orgsTableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "orgs"));
+        String paramsPath = "/orgs/{org}";
         Assertions.assertThat(orgsTableHandle.getSelectPaths()).containsExactly("/orgs/{org}");
         Assertions.assertThat(orgsTableHandle.getInsertPaths()).isEmpty();
         Assertions.assertThat(orgsTableHandle.getUpdatePaths()).isEmpty();
@@ -155,43 +156,43 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("description").setSourceName("description")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("name").setSourceName("name")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("company").setSourceName("company")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("blog").setSourceName("blog")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("location").setSourceName("location")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("email").setSourceName("email")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("twitter_username").setSourceName("twitter_username")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
@@ -202,13 +203,13 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("has_organization_projects").setSourceName("has_organization_projects")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("has_repository_projects").setSourceName("has_repository_projects")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
@@ -263,7 +264,7 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("billing_email").setSourceName("billing_email")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
@@ -279,13 +280,13 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("default_repository_permission").setSourceName("default_repository_permission")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_repositories").setSourceName("members_can_create_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
@@ -296,61 +297,61 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("members_allowed_repository_creation_type").setSourceName("members_allowed_repository_creation_type")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_public_repositories").setSourceName("members_can_create_public_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_private_repositories").setSourceName("members_can_create_private_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_internal_repositories").setSourceName("members_can_create_internal_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_pages").setSourceName("members_can_create_pages")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_public_pages").setSourceName("members_can_create_public_pages")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_private_pages").setSourceName("members_can_create_private_pages")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_fork_private_repositories").setSourceName("members_can_fork_private_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("web_commit_signoff_required").setSourceName("web_commit_signoff_required")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("advanced_security_enabled_for_new_repositories").setSourceName("advanced_security_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether GitHub Advanced Security is enabled for new repositories and repositories transferred to this organization.
@@ -360,7 +361,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("dependabot_alerts_enabled_for_new_repositories").setSourceName("dependabot_alerts_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether GitHub Advanced Security is automatically enabled for new repositories and repositories transferred to
@@ -371,7 +372,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("dependabot_security_updates_enabled_for_new_repositories").setSourceName("dependabot_security_updates_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether dependabot security updates are automatically enabled for new repositories and repositories transferred
@@ -382,7 +383,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("dependency_graph_enabled_for_new_repositories").setSourceName("dependency_graph_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether dependency graph is automatically enabled for new repositories and repositories transferred to this
@@ -393,7 +394,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("secret_scanning_enabled_for_new_repositories").setSourceName("secret_scanning_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether secret scanning is automatically enabled for new repositories and repositories transferred to this
@@ -404,7 +405,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("secret_scanning_push_protection_enabled_for_new_repositories").setSourceName("secret_scanning_push_protection_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether secret scanning push protection is automatically enabled for new repositories and repositories
@@ -415,14 +416,14 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("secret_scanning_push_protection_custom_link_enabled").setSourceName("secret_scanning_push_protection_custom_link_enabled")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("Whether a custom link is shown to contributors who are blocked from pushing a secret by push protection.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("secret_scanning_push_protection_custom_link").setSourceName("secret_scanning_push_protection_custom_link")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("An optional URL string to display to contributors who are blocked from pushing a secret.")
                                 .build(),
@@ -443,14 +444,16 @@ This field is only visible to organization owners or members of a team with the 
                                 .setName("org").setSourceName("org")
                                 .setType(VARCHAR).setSourceType(stringSchema)
                                 .setRequiresPredicate(Map.of(
-                                        PathItem.HttpMethod.GET, ParameterLocation.PATH,
-                                        PathItem.HttpMethod.PATCH, ParameterLocation.PATH,
-                                        PathItem.HttpMethod.DELETE, ParameterLocation.PATH))
+                                        new HttpPath(PathItem.HttpMethod.GET, paramsPath), ParameterLocation.PATH,
+                                        new HttpPath(PathItem.HttpMethod.PATCH, paramsPath), ParameterLocation.PATH,
+                                        new HttpPath(PathItem.HttpMethod.DELETE, paramsPath), ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build());
 
         OpenApiTableHandle workflowTableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "repos_actions_workflows"));
-        Assertions.assertThat(workflowTableHandle.getSelectPaths()).containsExactly("/repos/{owner}/{repo}/actions/workflows", "/repos/{owner}/{repo}/actions/workflows/{workflow_id}");
+        String listPath = "/repos/{owner}/{repo}/actions/workflows";
+        String onePath = "/repos/{owner}/{repo}/actions/workflows/{workflow_id}";
+        Assertions.assertThat(workflowTableHandle.getSelectPaths()).containsExactly(listPath, onePath);
         Assertions.assertThat(workflowTableHandle.getInsertPaths()).isEmpty();
         Assertions.assertThat(workflowTableHandle.getUpdatePaths()).isEmpty();
         Assertions.assertThat(workflowTableHandle.getDeletePaths()).isEmpty();
@@ -539,26 +542,30 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("owner").setSourceName("owner")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.PATH))
+                                .setRequiresPredicate(Map.of(
+                                        new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.PATH,
+                                        new HttpPath(PathItem.HttpMethod.GET, onePath), ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("repo").setSourceName("repo")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.PATH))
+                                .setRequiresPredicate(Map.of(
+                                        new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.PATH,
+                                        new HttpPath(PathItem.HttpMethod.GET, onePath), ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("per_page").setSourceName("per_page")
                                 .setType(BIGINT).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setIsHidden(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("page").setSourceName("page")
                                 .setType(BIGINT).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setIsHidden(true)
                                 .setIsPageNumber(true)
@@ -566,7 +573,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("workflow_id").setSourceName("workflow_id")
                                 .setType(VARCHAR).setSourceType(nullSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.PATH))
+                                .setRequiresPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, onePath), ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build());
     }
@@ -584,9 +591,10 @@ This field is only visible to organization owners or members of a team with the 
         Assertions.assertThat(tables.keySet()).containsAll(expected);
 
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "rest_api_3_search"));
-        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/rest/api/3/search");
-        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly("/rest/api/3/search");
-        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly("/rest/api/3/search");
+        String path = "/rest/api/3/search";
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly(path);
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly(path);
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly(path);
         Assertions.assertThat(tableHandle.getDeletePaths()).isEmpty();
         List<OpenApiColumn> columns = tables.get("rest_api_3_search").stream()
                 .map(column -> {
@@ -635,7 +643,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("expand").setSourceName("expand")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Expand options that include additional search result details in the response.")
                                 .build(),
@@ -648,7 +656,9 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("max_results").setSourceName("maxResults")
                                 .setType(INTEGER).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(
+                                        new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("The maximum number of results that could be on the page.")
                                 .build(),
@@ -667,7 +677,9 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("start_at").setSourceName("startAt")
                                 .setType(INTEGER).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(
+                                        new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("The index of the first item returned on the page.")
                                 .build(),
@@ -686,37 +698,37 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("jql").setSourceName("jql")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY, new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("validate_query").setSourceName("validateQuery")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY, new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("fields").setSourceName("fields")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY, new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("properties").setSourceName("properties")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY, new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("fields_by_keys").setSourceName("fieldsByKeys")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY, new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("expand_req").setSourceName("expand")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("Use [expand](em>#expansion) to include additional information about issues in the response. Note that, unlike the majority of instances where `expand` is specified, `expand` is defined as a list of values. The expand options are:\n" +
                                         "\n" +
@@ -778,10 +790,12 @@ This field is only visible to organization owners or members of a team with the 
                 "pet");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "pet"));
-        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/pet/{petId}");
-        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly("/pet", "/pet/{petId}");
-        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly("/pet", "/pet/{petId}");
-        Assertions.assertThat(tableHandle.getDeletePaths()).containsExactly("/pet/{petId}");
+        String listPath = "/pet";
+        String onePath = "/pet/{petId}";
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly(onePath);
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly(listPath, onePath);
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly(listPath, onePath);
+        Assertions.assertThat(tableHandle.getDeletePaths()).containsExactly(onePath);
         List<OpenApiColumn> petColumns = tables.get("pet").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute
@@ -808,48 +822,49 @@ This field is only visible to organization owners or members of a team with the 
                                 .setName("id").setSourceName("id")
                                 .setType(BIGINT).setSourceType(intSchema)
                                 .setOptionalPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
-                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
+                                        new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.PUT, listPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("name").setSourceName("name")
                                 .setType(VARCHAR).setSourceType(stringSchema)
                                 .setRequiresPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
-                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.QUERY))
+                                        new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.PUT, listPath), ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, onePath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("category").setSourceName("category")
                                 .setType(categoryType).setSourceType(objectSchema)
                                 .setOptionalPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
-                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
+                                        new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.PUT, listPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("photo_urls").setSourceName("photoUrls")
                                 .setType(photosType).setSourceType(arraySchema)
                                 .setRequiresPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
-                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
+                                        new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.PUT, listPath), ParameterLocation.BODY))
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("tags").setSourceName("tags")
                                 .setType(tagsType).setSourceType(arraySchema)
                                 .setOptionalPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
-                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
+                                        new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.PUT, listPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("status").setSourceName("status")
                                 .setType(VARCHAR).setSourceType(stringSchema)
                                 .setOptionalPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
-                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
+                                        new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.POST, onePath), ParameterLocation.QUERY,
+                                        new HttpPath(PathItem.HttpMethod.PUT, listPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("pet status in the store")
                                 .build(),
@@ -857,15 +872,15 @@ This field is only visible to organization owners or members of a team with the 
                                 .setName("pet_id").setSourceName("petId")
                                 .setType(BIGINT).setSourceType(intSchema)
                                 .setRequiresPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, ParameterLocation.PATH,
-                                        PathItem.HttpMethod.GET, ParameterLocation.PATH,
-                                        PathItem.HttpMethod.DELETE, ParameterLocation.PATH))
+                                        new HttpPath(PathItem.HttpMethod.POST, onePath), ParameterLocation.PATH,
+                                        new HttpPath(PathItem.HttpMethod.GET, onePath), ParameterLocation.PATH,
+                                        new HttpPath(PathItem.HttpMethod.DELETE, onePath), ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("api_key").setSourceName("api_key")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.DELETE, ParameterLocation.HEADER))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.DELETE, onePath), ParameterLocation.HEADER))
                                 .setIsNullable(true)
                                 .build());
     }
@@ -883,9 +898,10 @@ This field is only visible to organization owners or members of a team with the 
                 "api_v2_query_timeseries");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "api_v2_query_timeseries"));
-        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/api/v2/query/timeseries");
-        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly("/api/v2/query/timeseries");
-        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly("/api/v2/query/timeseries");
+        String path = "/api/v2/query/timeseries";
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly(path);
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly(path);
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly(path);
         Assertions.assertThat(tableHandle.getDeletePaths()).isEmpty();
         List<OpenApiColumn> columns = tables.get("api_v2_query_timeseries").stream()
                 .map(column -> {
@@ -945,7 +961,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("data_req").setSourceName("data")
                                 .setType(dataReqType).setSourceType(objectSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
+                                .setRequiresPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, path), ParameterLocation.BODY))
                                 .setComment("A single timeseries query to be executed.")
                                 .build());
     }
@@ -963,10 +979,12 @@ This field is only visible to organization owners or members of a team with the 
                 "zones");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "zones"));
-        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/zones", "/zones/{identifier}");
-        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly("/zones");
-        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly("/zones");
-        Assertions.assertThat(tableHandle.getDeletePaths()).containsExactly("/zones/{identifier}");
+        String listPath = "/zones";
+        String onePath = "/zones/{identifier}";
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly(listPath, onePath);
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly(listPath);
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly(listPath);
+        Assertions.assertThat(tableHandle.getDeletePaths()).containsExactly(onePath);
         List<OpenApiColumn> columns = tables.get("zones").stream()
                 .map(column -> {
                     // compare only source types, so rebuild it without any other attribute
@@ -1056,8 +1074,8 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("name").setSourceName("name")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setRequiresPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setComment("A domain name. Optional filter operators can be provided to extend refine the search:\n" +
                                         "  * `equal` (default)\n" +
                                         "  * `not_equal`\n" +
@@ -1072,21 +1090,21 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("status").setSourceName("status")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("A zone status")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("account.id").setSourceName("account.id")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("An account ID")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("account.name").setSourceName("account.name")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("An account Name. Optional filter operators can be provided to extend refine the search:\n" +
                                         "  * `equal` (default)\n" +
@@ -1101,47 +1119,49 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("page").setSourceName("page")
                                 .setType(createDecimalType(18, 8)).setSourceType(numberSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Page number of paginated results.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("per_page").setSourceName("per_page")
                                 .setType(createDecimalType(18, 8)).setSourceType(numberSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Number of zones per page.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("order").setSourceName("order")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Field to order zones by.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("direction").setSourceName("direction")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Direction to order zones.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("match").setSourceName("match")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, listPath), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Whether to match all search requirements or at least one (any).")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("account").setSourceName("account")
                                 .setType(RowType.from(List.of(RowType.field("id", VARCHAR)))).setSourceType(objectSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
+                                .setRequiresPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY))
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("type").setSourceName("type")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(
+                                        new HttpPath(PathItem.HttpMethod.POST, listPath), ParameterLocation.BODY,
+                                        new HttpPath(PathItem.HttpMethod.PATCH, onePath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("A full zone implies that DNS is hosted with Cloudflare. A partial zone is \n" +
                                         "typically a partner-hosted zone or a CNAME setup.\n")
@@ -1150,14 +1170,17 @@ This field is only visible to organization owners or members of a team with the 
                                 .setName("identifier").setSourceName("identifier")
                                 .setType(VARCHAR).setSourceType(stringSchema)
                                 // TODO we've merged /zones and /zones/{identifier} and now we require identifier for /zones, which is wrong
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.PATH, PathItem.HttpMethod.DELETE, ParameterLocation.PATH, PathItem.HttpMethod.PATCH, ParameterLocation.PATH))
+                                .setRequiresPredicate(Map.of(
+                                        new HttpPath(PathItem.HttpMethod.GET, onePath), ParameterLocation.PATH,
+                                        new HttpPath(PathItem.HttpMethod.DELETE, onePath), ParameterLocation.PATH,
+                                        new HttpPath(PathItem.HttpMethod.PATCH, onePath), ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .setComment("Identifier")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("paused").setSourceName("paused")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, onePath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("Indicates whether the zone is only using Cloudflare DNS services. A\n" +
                                         "true value means the zone will not receive security or performance\n" +
@@ -1166,7 +1189,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("plan").setSourceName("plan")
                                 .setType(RowType.from(List.of(RowType.field("id", VARCHAR)))).setSourceType(objectSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, onePath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("(Deprecated) Please use the `/zones/{identifier}/subscription` API\n" +
                                         "to update a zone's plan. Changing this value will create/cancel\n" +
@@ -1176,7 +1199,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("vanity_name_servers").setSourceName("vanity_name_servers")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.PATCH, onePath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("An array of domains used for custom name servers. This is only\n" +
                                         "available for Business and Enterprise plans.")
@@ -1193,7 +1216,8 @@ This field is only visible to organization owners or members of a team with the 
                 "v1_forecast");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "v1_forecast"));
-        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly("/v1/forecast");
+        String path = "/v1/forecast";
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly(path);
         Assertions.assertThat(tableHandle.getInsertPaths()).isEmpty();
         Assertions.assertThat(tableHandle.getUpdatePaths()).isEmpty();
         Assertions.assertThat(tableHandle.getDeletePaths()).isEmpty();
@@ -1335,61 +1359,61 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("hourly_req").setSourceName("hourly")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("daily_req").setSourceName("daily")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("latitude_req").setSourceName("latitude")
                                 .setType(REAL).setSourceType(numberSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setRequiresPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("longitude_req").setSourceName("longitude")
                                 .setType(REAL).setSourceType(numberSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setRequiresPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("current_weather_req").setSourceName("current_weather")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("temperature_unit").setSourceName("temperature_unit")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("wind_speed_unit").setSourceName("wind_speed_unit")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("timeformat").setSourceName("timeformat")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("timezone").setSourceName("timezone")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("past_days").setSourceName("past_days")
                                 .setType(BIGINT).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.GET, path), ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build());
     }
@@ -1456,6 +1480,13 @@ This field is only visible to organization owners or members of a team with the 
         OpenApiSpec spec = parseSpec(specContents);
         Map<String, List<OpenApiColumn>> tables = spec.getTables();
 
+        String postPath = "/namespaces/{namespace}/indexes/{index}/search";
+        OpenApiTableHandle tableHandle = spec.getTableHandle(schemaTableName(SCHEMA_NAME, "namespaces_indexes_search"));
+        Assertions.assertThat(tableHandle.getSelectPaths()).containsExactly(postPath);
+        Assertions.assertThat(tableHandle.getInsertPaths()).containsExactly(postPath);
+        Assertions.assertThat(tableHandle.getUpdatePaths()).containsExactly(postPath);
+        Assertions.assertThat(tableHandle.getDeletePaths()).isEmpty();
+
         Set<String> expected = Set.of("namespaces_indexes_search");
         Assertions.assertThat(tables.keySet()).containsAll(expected);
         List<OpenApiColumn> columns = tables.get("namespaces_indexes_search").stream()
@@ -1478,19 +1509,19 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("id").setSourceName("id")
                                 .setType(BIGINT).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, postPath), ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("namespace").setSourceName("namespace")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.PATH))
+                                .setRequiresPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, postPath), ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("index").setSourceName("index")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.PATH))
+                                .setRequiresPredicate(Map.of(new HttpPath(PathItem.HttpMethod.POST, postPath), ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build());
     }

--- a/src/test/java/pl/net/was/TestOpenApiSpec.java
+++ b/src/test/java/pl/net/was/TestOpenApiSpec.java
@@ -155,43 +155,43 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("description").setSourceName("description")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("name").setSourceName("name")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("company").setSourceName("company")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("blog").setSourceName("blog")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("location").setSourceName("location")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("email").setSourceName("email")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("twitter_username").setSourceName("twitter_username")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
@@ -202,13 +202,13 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("has_organization_projects").setSourceName("has_organization_projects")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("has_repository_projects").setSourceName("has_repository_projects")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
@@ -263,7 +263,7 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("billing_email").setSourceName("billing_email")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
@@ -279,13 +279,13 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("default_repository_permission").setSourceName("default_repository_permission")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_repositories").setSourceName("members_can_create_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
@@ -296,61 +296,61 @@ class TestOpenApiSpec
                         OpenApiColumn.builder()
                                 .setName("members_allowed_repository_creation_type").setSourceName("members_allowed_repository_creation_type")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_public_repositories").setSourceName("members_can_create_public_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_private_repositories").setSourceName("members_can_create_private_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_internal_repositories").setSourceName("members_can_create_internal_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_pages").setSourceName("members_can_create_pages")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_public_pages").setSourceName("members_can_create_public_pages")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_create_private_pages").setSourceName("members_can_create_private_pages")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("members_can_fork_private_repositories").setSourceName("members_can_fork_private_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("web_commit_signoff_required").setSourceName("web_commit_signoff_required")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("advanced_security_enabled_for_new_repositories").setSourceName("advanced_security_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether GitHub Advanced Security is enabled for new repositories and repositories transferred to this organization.
@@ -360,7 +360,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("dependabot_alerts_enabled_for_new_repositories").setSourceName("dependabot_alerts_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether GitHub Advanced Security is automatically enabled for new repositories and repositories transferred to
@@ -371,7 +371,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("dependabot_security_updates_enabled_for_new_repositories").setSourceName("dependabot_security_updates_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether dependabot security updates are automatically enabled for new repositories and repositories transferred
@@ -382,7 +382,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("dependency_graph_enabled_for_new_repositories").setSourceName("dependency_graph_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether dependency graph is automatically enabled for new repositories and repositories transferred to this
@@ -393,7 +393,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("secret_scanning_enabled_for_new_repositories").setSourceName("secret_scanning_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether secret scanning is automatically enabled for new repositories and repositories transferred to this
@@ -404,7 +404,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("secret_scanning_push_protection_enabled_for_new_repositories").setSourceName("secret_scanning_push_protection_enabled_for_new_repositories")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("""
 Whether secret scanning push protection is automatically enabled for new repositories and repositories
@@ -415,14 +415,14 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("secret_scanning_push_protection_custom_link_enabled").setSourceName("secret_scanning_push_protection_custom_link_enabled")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("Whether a custom link is shown to contributors who are blocked from pushing a secret by push protection.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("secret_scanning_push_protection_custom_link").setSourceName("secret_scanning_push_protection_custom_link")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("An optional URL string to display to contributors who are blocked from pushing a secret.")
                                 .build(),
@@ -443,9 +443,9 @@ This field is only visible to organization owners or members of a team with the 
                                 .setName("org").setSourceName("org")
                                 .setType(VARCHAR).setSourceType(stringSchema)
                                 .setRequiresPredicate(Map.of(
-                                        PathItem.HttpMethod.GET, "path",
-                                        PathItem.HttpMethod.PATCH, "path",
-                                        PathItem.HttpMethod.DELETE, "path"))
+                                        PathItem.HttpMethod.GET, ParameterLocation.PATH,
+                                        PathItem.HttpMethod.PATCH, ParameterLocation.PATH,
+                                        PathItem.HttpMethod.DELETE, ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build());
 
@@ -539,26 +539,26 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("owner").setSourceName("owner")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, "path"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("repo").setSourceName("repo")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, "path"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("per_page").setSourceName("per_page")
                                 .setType(BIGINT).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setIsHidden(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("page").setSourceName("page")
                                 .setType(BIGINT).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setIsHidden(true)
                                 .setIsPageNumber(true)
@@ -566,7 +566,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("workflow_id").setSourceName("workflow_id")
                                 .setType(VARCHAR).setSourceType(nullSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, "path"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build());
     }
@@ -635,7 +635,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("expand").setSourceName("expand")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Expand options that include additional search result details in the response.")
                                 .build(),
@@ -648,7 +648,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("max_results").setSourceName("maxResults")
                                 .setType(INTEGER).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body", PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("The maximum number of results that could be on the page.")
                                 .build(),
@@ -667,7 +667,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("start_at").setSourceName("startAt")
                                 .setType(INTEGER).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body", PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("The index of the first item returned on the page.")
                                 .build(),
@@ -686,37 +686,37 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("jql").setSourceName("jql")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body", PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("validate_query").setSourceName("validateQuery")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body", PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("fields").setSourceName("fields")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body", PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("properties").setSourceName("properties")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body", PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("fields_by_keys").setSourceName("fieldsByKeys")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body", PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("expand_req").setSourceName("expand")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("Use [expand](em>#expansion) to include additional information about issues in the response. Note that, unlike the majority of instances where `expand` is specified, `expand` is defined as a list of values. The expand options are:\n" +
                                         "\n" +
@@ -808,48 +808,48 @@ This field is only visible to organization owners or members of a team with the 
                                 .setName("id").setSourceName("id")
                                 .setType(BIGINT).setSourceType(intSchema)
                                 .setOptionalPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, "body",
-                                        PathItem.HttpMethod.PUT, "body"))
+                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
+                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("name").setSourceName("name")
                                 .setType(VARCHAR).setSourceType(stringSchema)
                                 .setRequiresPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, "body",
-                                        PathItem.HttpMethod.PUT, "body"))
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "query"))
+                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
+                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("category").setSourceName("category")
                                 .setType(categoryType).setSourceType(objectSchema)
                                 .setOptionalPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, "body",
-                                        PathItem.HttpMethod.PUT, "body"))
+                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
+                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("photo_urls").setSourceName("photoUrls")
                                 .setType(photosType).setSourceType(arraySchema)
                                 .setRequiresPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, "body",
-                                        PathItem.HttpMethod.PUT, "body"))
+                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
+                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("tags").setSourceName("tags")
                                 .setType(tagsType).setSourceType(arraySchema)
                                 .setOptionalPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, "body",
-                                        PathItem.HttpMethod.PUT, "body"))
+                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
+                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("status").setSourceName("status")
                                 .setType(VARCHAR).setSourceType(stringSchema)
                                 .setOptionalPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, "body",
-                                        PathItem.HttpMethod.PUT, "body"))
+                                        PathItem.HttpMethod.POST, ParameterLocation.BODY,
+                                        PathItem.HttpMethod.PUT, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("pet status in the store")
                                 .build(),
@@ -857,15 +857,15 @@ This field is only visible to organization owners or members of a team with the 
                                 .setName("pet_id").setSourceName("petId")
                                 .setType(BIGINT).setSourceType(intSchema)
                                 .setRequiresPredicate(Map.of(
-                                        PathItem.HttpMethod.POST, "path",
-                                        PathItem.HttpMethod.GET, "path",
-                                        PathItem.HttpMethod.DELETE, "path"))
+                                        PathItem.HttpMethod.POST, ParameterLocation.PATH,
+                                        PathItem.HttpMethod.GET, ParameterLocation.PATH,
+                                        PathItem.HttpMethod.DELETE, ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("api_key").setSourceName("api_key")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.DELETE, "header"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.DELETE, ParameterLocation.HEADER))
                                 .setIsNullable(true)
                                 .build());
     }
@@ -945,7 +945,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("data_req").setSourceName("data")
                                 .setType(dataReqType).setSourceType(objectSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, "body"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
                                 .setComment("A single timeseries query to be executed.")
                                 .build());
     }
@@ -1056,8 +1056,8 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("name").setSourceName("name")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, "body"))
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setComment("A domain name. Optional filter operators can be provided to extend refine the search:\n" +
                                         "  * `equal` (default)\n" +
                                         "  * `not_equal`\n" +
@@ -1072,21 +1072,21 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("status").setSourceName("status")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("A zone status")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("account.id").setSourceName("account.id")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("An account ID")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("account.name").setSourceName("account.name")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("An account Name. Optional filter operators can be provided to extend refine the search:\n" +
                                         "  * `equal` (default)\n" +
@@ -1101,47 +1101,47 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("page").setSourceName("page")
                                 .setType(createDecimalType(18, 8)).setSourceType(numberSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Page number of paginated results.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("per_page").setSourceName("per_page")
                                 .setType(createDecimalType(18, 8)).setSourceType(numberSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Number of zones per page.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("order").setSourceName("order")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Field to order zones by.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("direction").setSourceName("direction")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Direction to order zones.")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("match").setSourceName("match")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .setComment("Whether to match all search requirements or at least one (any).")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("account").setSourceName("account")
                                 .setType(RowType.from(List.of(RowType.field("id", VARCHAR)))).setSourceType(objectSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, "body"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("type").setSourceName("type")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body", PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY, PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("A full zone implies that DNS is hosted with Cloudflare. A partial zone is \n" +
                                         "typically a partner-hosted zone or a CNAME setup.\n")
@@ -1150,14 +1150,14 @@ This field is only visible to organization owners or members of a team with the 
                                 .setName("identifier").setSourceName("identifier")
                                 .setType(VARCHAR).setSourceType(stringSchema)
                                 // TODO we've merged /zones and /zones/{identifier} and now we require identifier for /zones, which is wrong
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, "path", PathItem.HttpMethod.DELETE, "path", PathItem.HttpMethod.PATCH, "path"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.PATH, PathItem.HttpMethod.DELETE, ParameterLocation.PATH, PathItem.HttpMethod.PATCH, ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .setComment("Identifier")
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("paused").setSourceName("paused")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("Indicates whether the zone is only using Cloudflare DNS services. A\n" +
                                         "true value means the zone will not receive security or performance\n" +
@@ -1166,7 +1166,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("plan").setSourceName("plan")
                                 .setType(RowType.from(List.of(RowType.field("id", VARCHAR)))).setSourceType(objectSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("(Deprecated) Please use the `/zones/{identifier}/subscription` API\n" +
                                         "to update a zone's plan. Changing this value will create/cancel\n" +
@@ -1176,7 +1176,7 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("vanity_name_servers").setSourceName("vanity_name_servers")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.PATCH, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .setComment("An array of domains used for custom name servers. This is only\n" +
                                         "available for Business and Enterprise plans.")
@@ -1335,61 +1335,61 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("hourly_req").setSourceName("hourly")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("daily_req").setSourceName("daily")
                                 .setType(new ArrayType(VARCHAR)).setSourceType(arraySchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("latitude_req").setSourceName("latitude")
                                 .setType(REAL).setSourceType(numberSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("longitude_req").setSourceName("longitude")
                                 .setType(REAL).setSourceType(numberSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("current_weather_req").setSourceName("current_weather")
                                 .setType(BOOLEAN).setSourceType(booleanSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("temperature_unit").setSourceName("temperature_unit")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("wind_speed_unit").setSourceName("wind_speed_unit")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("timeformat").setSourceName("timeformat")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("timezone").setSourceName("timezone")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("past_days").setSourceName("past_days")
                                 .setType(BIGINT).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, "query"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.GET, ParameterLocation.QUERY))
                                 .setIsNullable(true)
                                 .build());
     }
@@ -1478,19 +1478,19 @@ This field is only visible to organization owners or members of a team with the 
                         OpenApiColumn.builder()
                                 .setName("id").setSourceName("id")
                                 .setType(BIGINT).setSourceType(intSchema)
-                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, "body"))
+                                .setOptionalPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.BODY))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("namespace").setSourceName("namespace")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, "path"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build(),
                         OpenApiColumn.builder()
                                 .setName("index").setSourceName("index")
                                 .setType(VARCHAR).setSourceType(stringSchema)
-                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, "path"))
+                                .setRequiresPredicate(Map.of(PathItem.HttpMethod.POST, ParameterLocation.PATH))
                                 .setIsNullable(true)
                                 .build());
     }

--- a/src/test/resources/fastapi/main.py
+++ b/src/test/resources/fastapi/main.py
@@ -1,9 +1,60 @@
+import logging
 from datetime import date, datetime
+from typing import Callable
 
-from fastapi import FastAPI, HTTPException
+from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
+from fastapi.routing import APIRoute
 from pydantic import BaseModel
+from starlette.background import BackgroundTask
+from starlette.responses import StreamingResponse
+
+
+def log_info(req_body, res_body):
+    logging.info(f"Request: {req_body}")
+    logging.info(f"Response: {res_body}")
+
+
+class LoggingRoute(APIRoute):
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            req_body = await request.body()
+            response = await original_route_handler(request)
+            tasks = response.background
+
+            if isinstance(response, StreamingResponse):
+                chunks = []
+                async for chunk in response.body_iterator:
+                    chunks.append(chunk)
+                res_body = b"".join(chunks)
+
+                task = BackgroundTask(log_info, req_body, res_body)
+                response = Response(
+                    content=res_body,
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                    media_type=response.media_type,
+                )
+            else:
+                task = BackgroundTask(log_info, req_body, response.body)
+
+            # check if the original response had background tasks already attached to it
+            if tasks:
+                tasks.add_task(task)  # add the new task to the tasks list
+                response.background = tasks
+            else:
+                response.background = task
+
+            return response
+
+        return custom_route_handler
+
 
 app = FastAPI()
+router = APIRouter(route_class=LoggingRoute)
+logging.basicConfig(format="%(asctime)s %(levelname)s:%(name)s:%(message)s", level=logging.DEBUG)
+
 
 class Item(BaseModel):
     id: str
@@ -17,24 +68,32 @@ class Item(BaseModel):
     validUntil: date = None
     revisedAt: list[date] = []
 
+
 class ItemFilter(BaseModel):
     item_ids: list[str] = []
+
 
 items = {
     1: Item(id="1", name="Portal Gun", price=42.0, tags=["sci-fi"], revisedAt=["2007-10-10", "2022-12-08"]),
     2: Item(id="2", name="Plumbus", price=32.0, validUntil="2999-01-01", properties={"feeble": "schleem"}),
 }
 
-@app.get("/")
+
+@router.get("/")
 def root():
     return {"Hello": "World"}
 
-@app.post("/search")
-def search_items(q: ItemFilter) -> list[Item]:
-    return filter(lambda item: item.id in q.item_ids,items.values())
 
-@app.get("/items/{item_id}")
+@router.post("/search")
+def search_items(q: ItemFilter) -> list[Item]:
+    return filter(lambda item: item.id in q.item_ids, items.values())
+
+
+@router.get("/items/{item_id}")
 def get_item(item_id: int) -> Item:
     if item_id not in items:
         raise HTTPException(status_code=404, detail="Item not found")
     return items[item_id]
+
+
+app.include_router(router)


### PR DESCRIPTION
Significantly improve mapping multiple paths to one table. Paths are now selected based on query predicates. The connector should no longer throw errors when trying to make a request to a path with path parameters because they were not replaced in the URL. This is done for both reads and writes.

Fixes #166 